### PR TITLE
9p: getattr: use fstat if we have a fd

### DIFF
--- a/hw/9pfs/9p.c
+++ b/hw/9pfs/9p.c
@@ -1100,7 +1100,11 @@ static void v9fs_getattr(void *opaque)
      * Currently we only support BASIC fields in stat, so there is no
      * need to look at request_mask.
      */
-    retval = v9fs_co_lstat(pdu, &fidp->path, &stbuf);
+    if (fidp->fs.fd > 0) {
+        retval = v9fs_co_fstat(pdu, fidp, &stbuf);
+    } else {
+        retval = v9fs_co_lstat(pdu, &fidp->path, &stbuf);
+    }
     if (retval < 0) {
         goto out;
     }


### PR DESCRIPTION
If we have an opened fd, it is better to call fstat() as the underlying
file may have been unlinked and lstat() will fail.

Signed-off-by: Greg Kurz gkurz@linux.vnet.ibm.com
